### PR TITLE
Add skinmod integration via FoxelineConfig.yaml

### DIFF
--- a/Source/CelesteNetHelper.cs
+++ b/Source/CelesteNetHelper.cs
@@ -21,23 +21,45 @@ public class TailData : DataType<TailData> {
 
     public TailData() {}
     public TailData(DataPlayerInfo player) {
-        Player = player;
-        TailInformation = new FoxelineModuleSettings.TailDefaults() {
-            Tail = FoxelineModule.Settings.Tail,
-            TailBrushTint = FoxelineModule.Settings.TailBrushTint,
-            TailScale = FoxelineModule.Settings.TailScale,
-            FeatherTail = FoxelineModule.Settings.FeatherTail,
-            PaintBrushTail = FoxelineModule.Settings.PaintBrushTail
-        };
+        var config = FoxelineHelpers.TryGetActiveSkinTailConfig();
+
+        if (config != null) {
+            TailInformation = new FoxelineModuleSettings.TailDefaults() {
+                Tail = config.TailEnum,
+                TailBrushTint = config.TailBrushTint,
+                TailScale = config.TailScale,
+                FeatherTail = config.FeatherTail,
+                PaintBrushTail = config.PaintBrushTail
+            };
+        }
+        else {
+            TailInformation = new FoxelineModuleSettings.TailDefaults() {
+                Tail = FoxelineModule.Settings.Tail,
+                TailBrushTint = FoxelineModule.Settings.TailBrushTint,
+                TailScale = FoxelineModule.Settings.TailScale,
+                FeatherTail = FoxelineModule.Settings.FeatherTail,
+                PaintBrushTail = FoxelineModule.Settings.PaintBrushTail
+            };
+        }
     }
 
     public override bool FilterHandle(DataContext ctx)
         => Player != null;
 
-    public override MetaType[] GenerateMeta(DataContext ctx) => [
-        new MetaPlayerPrivateState(Player),
-        new MetaBoundRef(DataType<DataPlayerInfo>.DataID, Player?.ID ?? uint.MaxValue, true),
-    ];
+
+    // I don't have collection literals, I'm very sorry.
+    //public override MetaType[] GenerateMeta(DataContext ctx) => [
+    //    new MetaPlayerPrivateState(Player),
+    //    new MetaBoundRef(DataType<DataPlayerInfo>.DataID, Player?.ID ?? uint.MaxValue, true),
+    //];
+
+    public override MetaType[] GenerateMeta(DataContext ctx) {
+        return new MetaType[] {
+            new MetaPlayerPrivateState(Player),
+            new MetaBoundRef(DataType<DataPlayerInfo>.DataID, Player?.ID ?? uint.MaxValue, true),
+        };
+    }
+
 
     public override void FixupMeta(DataContext ctx) {
         Player = Get<MetaPlayerPrivateState>(ctx);

--- a/Source/FoxelineHelpers.cs
+++ b/Source/FoxelineHelpers.cs
@@ -9,6 +9,8 @@ using Celeste.Mod.CelesteNet.Client;
 using Celeste.Mod.CelesteNet.Client.Entities;
 using System.Runtime.CompilerServices;
 using System.Linq;
+using Celeste.Mod.Foxeline.SkinIntegration;
+using static Celeste.Mod.Foxeline.SkinIntegration.FoxelineYaml;
 
 namespace Celeste.Mod.Foxeline
 {
@@ -40,6 +42,43 @@ namespace Celeste.Mod.Foxeline
 
     public static class FoxelineHelpers
     {
+
+#nullable enable
+        /// <summary>
+        /// Gets the current active skin from SMH+
+        /// </summary>
+        /// <returns>String representing the skin name, null if not found</returns>
+        public static string? TryGetActiveSkinName()
+        {
+            if (Everest.Loader.TryGetDependency(new EverestModuleMetadata() { Name = "SkinModHelperPlus", Version = new Version(0, 9, 5) }, out var mod))
+            {
+                EverestModuleSettings SkinModHelper_Settings = mod._Settings;
+                if (SkinModHelper_Settings != null)
+                {
+                    return DynamicData.For(SkinModHelper_Settings).Get<string>("SelectedPlayerSkin");
+                }
+            }
+            return null;
+        }
+#nullable disable
+
+        /// <summary>
+        /// Gets the tail config of the current active skin
+        /// </summary>
+        /// <returns>FoxelineConfig of the active skin, null if not found or skinmod tails are disabled</returns>
+        public static FoxelineConfig TryGetActiveSkinTailConfig()
+        {
+            if (FoxelineModule.Settings.DisableSkinmodTails) {
+                return null;
+            }
+
+            if (SkinTailConfigs.TryGetValue(TryGetActiveSkinName(), out FoxelineConfig config))
+            {
+                return config;
+            }
+            return null;
+        }
+
         /// <summary>
         /// Gets the tail variant for the player based on the settings
         /// </summary>
@@ -50,7 +89,8 @@ namespace Celeste.Mod.Foxeline
         {
             if(isPlayerHair(self))
             {
-                return FoxelineModule.Settings.Tail;
+                var config = TryGetActiveSkinTailConfig();
+                return config == null ? FoxelineModule.Settings.Tail : config.TailEnum;
             }
             if(isBadelineHair(self))
             {
@@ -71,7 +111,9 @@ namespace Celeste.Mod.Foxeline
         {
             if(isPlayerHair(self))
             {
-                return FoxelineModule.Settings.TailScale / 100f;
+                var config = TryGetActiveSkinTailConfig();
+                return config == null ? FoxelineModule.Settings.TailScale / 100f : config.TailScale / 100f;
+
             }
             if(isBadelineHair(self))
             {
@@ -92,7 +134,8 @@ namespace Celeste.Mod.Foxeline
         {
             if(isPlayerHair(self))
             {
-                return FoxelineModule.Settings.PaintBrushTail;
+                var config = TryGetActiveSkinTailConfig();
+                return config == null ? FoxelineModule.Settings.PaintBrushTail : config.PaintBrushTail;
             }
             if(isBadelineHair(self))
             {
@@ -113,7 +156,8 @@ namespace Celeste.Mod.Foxeline
         {
             if(isPlayerHair(self))
             {
-                return FoxelineModule.Settings.TailBrushTint / 100f;
+                var config = TryGetActiveSkinTailConfig();
+                return config == null ? FoxelineModule.Settings.TailBrushTint / 100f : config.TailBrushTint / 100f;
             }
             if(isBadelineHair(self))
             {
@@ -134,7 +178,8 @@ namespace Celeste.Mod.Foxeline
         {
             if(isPlayerHair(self))
             {
-                return FoxelineModule.Settings.FeatherTail;
+                var config = TryGetActiveSkinTailConfig();
+                return config == null ? FoxelineModule.Settings.FeatherTail : config.FeatherTail;
             }
             if(isBadelineHair(self))
             {

--- a/Source/FoxelineHooks.cs
+++ b/Source/FoxelineHooks.cs
@@ -191,9 +191,9 @@ namespace Celeste.Mod.Foxeline
         public static void PlayerHair_ctor(On.Celeste.PlayerHair.orig_ctor orig, PlayerHair self, PlayerSprite sprite)
         {
             DynamicData selfData = DynamicData.For(self);
-            List<Vector2> tailPositions = [];
-            List<Vector2> tailOffsets = [];
-            List<Vector2> tailVelocities = [];
+            List<Vector2> tailPositions = new();
+            List<Vector2> tailOffsets = new();
+            List<Vector2> tailVelocities = new();
             selfData.Set(FoxelineConst.TailPositions, tailPositions);
             selfData.Set(FoxelineConst.Velocity, tailOffsets);
             selfData.Set(FoxelineConst.TailOffset, tailVelocities);
@@ -245,6 +245,11 @@ namespace Celeste.Mod.Foxeline
             return FoxelineModule.Instance.bangs[self.Sprite.HairFrame];
         }
 
+        public static void GameLoader_Begin(On.Celeste.GameLoader.orig_Begin orig, GameLoader self)
+        {
+            Foxeline.SkinIntegration.FoxelineYaml.ReloadYaml();
+            orig(self);
+        }
 
     }
 }

--- a/Source/FoxelineModule.cs
+++ b/Source/FoxelineModule.cs
@@ -51,8 +51,8 @@ namespace Celeste.Mod.Foxeline
             On.Celeste.PlayerHair.AfterUpdate += FoxelineHooks.PlayerHair_AfterUpdate;
             On.Celeste.PlayerHair.GetHairTexture += FoxelineHooks.Hair_GetTexture;
             On.Celeste.PlayerHair.MoveHairBy += FoxelineHooks.PlayerHair_MoveHairBy;
+            On.Celeste.GameLoader.Begin += FoxelineHooks.GameLoader_Begin; 
         }
-        
 
         public override void LoadContent(bool inGame)
         {
@@ -73,6 +73,7 @@ namespace Celeste.Mod.Foxeline
             On.Celeste.PlayerHair.AfterUpdate -= FoxelineHooks.PlayerHair_AfterUpdate;
             On.Celeste.PlayerHair.GetHairTexture -= FoxelineHooks.Hair_GetTexture;
             On.Celeste.PlayerHair.MoveHairBy -= FoxelineHooks.PlayerHair_MoveHairBy;
+            On.Celeste.GameLoader.Begin -= FoxelineHooks.GameLoader_Begin;
         }
     }
 }

--- a/Source/FoxelineModuleSettings.cs
+++ b/Source/FoxelineModuleSettings.cs
@@ -25,6 +25,8 @@ namespace Celeste.Mod.Foxeline
 
         [SettingSubText("(VANILLA/SMH PLUS ONLY)")]
         public bool FixCutscenes { get; set; } = true;
+        [SettingSubText("Disables skinmod tails defined by FoxelineConfig.yaml")]
+        public bool DisableSkinmodTails { get; set; } = false;
 
         [SettingSubText("Badeline's tail configuration")]
         public BadelineTailDefaults BadelineTail { get; set; } = new BadelineTailDefaults();

--- a/Source/SkinIntegration/FoxelineConfig.cs
+++ b/Source/SkinIntegration/FoxelineConfig.cs
@@ -1,0 +1,33 @@
+﻿namespace Celeste.Mod.Foxeline.SkinIntegration;
+
+public class FoxelineConfig
+{
+    public string SkinName = "";
+    public string Tail = "None"; //Yaml can't deserialize enums so we get a string and parse it to the enum.
+    public TailVariant TailEnum { get; set; } = TailVariant.None;
+    public int TailBrushTint { get; set; } = 15;
+    public int TailScale { get; set; } = 100;
+    public bool FeatherTail { get; set; } = true;
+    public bool PaintBrushTail { get; set; } = false;
+}
+
+
+/* YAML File Example
+ 
+ - SkinName: katz404_ParrotDash
+  Tail: Furry
+  TailbrushTint: 0
+  TailScale: 150
+  FeatherTail: true
+  PaintBrushTail: false
+ 
+  - SkinName: katz404_ParrotDash_Gradient
+  Tail: Furry
+  TailbrushTint: 0
+  TailScale: 150
+  FeatherTail: true
+  PaintBrushTail: false
+ 
+
+ 
+ */

--- a/Source/SkinIntegration/FoxelineYaml.cs
+++ b/Source/SkinIntegration/FoxelineYaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.Foxeline.SkinIntegration;
+
+public class FoxelineYaml
+{
+    public static Dictionary<string, FoxelineConfig> SkinTailConfigs = new(StringComparer.OrdinalIgnoreCase);
+
+    public static void ReloadYaml()
+    {
+        foreach (ModContent mod in Everest.Content.Mods)
+        {
+            if (!mod.Map.TryGetValue("FoxelineConfig", out ModAsset asset)) {
+                continue;
+            }
+            Logger.Info("Foxeline Yaml", $"Loading config from {mod.Name}");
+
+            if (!LoadConfigFile<List<FoxelineConfig>>(asset, out var configs) || configs.Count < 1) {
+                Logger.Warn("Foxeline Yaml", $"Failed deserializing config");
+                continue;
+            }
+
+            foreach (FoxelineConfig config in configs) {
+                if (!Enum.TryParse(config.Tail, out TailVariant TailString)) {
+                    Logger.Warn("Foxeline Yaml", $"Incorrect tail type \"{config.Tail}\"");
+                    continue;
+                }
+                config.TailEnum = TailString;
+                SkinTailConfigs[config.SkinName] = config;
+            }
+        }
+    }
+
+    public static bool LoadConfigFile<T>(ModAsset skinConfigYaml, out T t) {
+        return skinConfigYaml.TryDeserialize(out t);
+    }
+}
+


### PR DESCRIPTION
A hopefully soon to be obsolete feature that allows mods to include a FoxelineConfig.yaml file which defines tail settings for a specified smh+ skin.

(I just kinda want to test how this github pr thing works.)